### PR TITLE
fix exception when jwt is null

### DIFF
--- a/src/Support/JwtParser.php
+++ b/src/Support/JwtParser.php
@@ -19,7 +19,7 @@ class JwtParser
 
     private string $errorMessage = '';
     private array $claims;
-    private string|null $jwt = null;
+    private ?string $jwt;
     private string $publicKey;
     private string $idClaim;
     private string $rolesClaim;
@@ -28,7 +28,7 @@ class JwtParser
     private bool $validateIssuer = true;
     
     public function __construct(
-        string|null $jwt,
+        ?string $jwt,
         string $idClaim,
         string $publicKey,
         string $rolesClaim,

--- a/src/Support/JwtParser.php
+++ b/src/Support/JwtParser.php
@@ -19,7 +19,7 @@ class JwtParser
 
     private string $errorMessage = '';
     private array $claims;
-    private string $jwt;
+    private string|null $jwt = null;
     private string $publicKey;
     private string $idClaim;
     private string $rolesClaim;
@@ -28,7 +28,7 @@ class JwtParser
     private bool $validateIssuer = true;
     
     public function __construct(
-        string $jwt, 
+        string|null $jwt,
         string $idClaim,
         string $publicKey,
         string $rolesClaim,
@@ -45,6 +45,10 @@ class JwtParser
         $this->issuer = $issuer;
         $this->validateIssuer = $validateIssuer;
 
+        if (!$jwt) {
+            return;
+        }
+        
         if (!$this->validate()) {
             throw new JwtValidationException($this->errorMessage);
         }


### PR DESCRIPTION
when:
1. the guard is the default guard in config/auth.php
2. calling `auth()` on booting a model (or any early method in laravel life-cycle)
3. not providing a jwt 

note: this also happen when running larastan (which runs laravel application when analysing the app)
note: same when running `        RateLimiter::for('api', function (Request $request) {
            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
        });
` on RouteServerProvider
![CleanShot 2024-03-07 at 10 32 39](https://github.com/abublihi/laravel-external-jwt-guard/assets/41856121/d1c6bf2c-ffdf-4fb9-a2fb-58b65fe097e5)
