### PR TITLE
fix running guard in tests

### DIFF
--- a/src/JwtGuardDriver.php
+++ b/src/JwtGuardDriver.php
@@ -66,7 +66,7 @@ class JwtGuardDriver implements Guard
     public function user()
     {
         if (!$this->authorizationServerConfig || !$this->parsedJwt) {
-            return null;
+            return $this->user;
         }
 
         // If we've already retrieved the user for the current request we can just


### PR DESCRIPTION
this will add `return $this->user` (and user will be user or null) which will fix guard when running in tests